### PR TITLE
link libudev for udev_unref and udev_new

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -258,7 +258,7 @@ AS_IF([test "x$with_libinput" != "xno"],[
    if test "x${have_libinput}" = xyes; then
       AC_DEFINE(HAVE_LIBINPUT, 1, [Have libinput support])
       LIBEGT_EXTRA_CXXFLAGS="${LIBINPUT_CFLAGS} ${LIBEGT_EXTRA_CXXFLAGS}"
-      LIBEGT_EXTRA_LDFLAGS="${LIBINPUT_LIBS} ${LIBEGT_EXTRA_LDFLAGS}"
+      LIBEGT_EXTRA_LDFLAGS="${LIBINPUT_LIBS} -ludev ${LIBEGT_EXTRA_LDFLAGS}"
    fi
 ])
 AM_CONDITIONAL([HAVE_LIBINPUT], [test "x${have_libinput}" = xyes])


### PR DESCRIPTION
These APIs are used in inputlibinput.cpp which is only
compile when HAVE_LIBINPUT is enabled

This shows up when linking with gold linker

../../src/.libs/libegt.so: error: undefined reference to 'udev_new'
../../src/.libs/libegt.so: error: undefined reference to 'udev_unref'
collect2: error: ld returned 1 exit status
Makefile:558: recipe for target 'camera' failed
make[4]: *** [camera] Error 1

Signed-off-by: Khem Raj <raj.khem@gmail.com>