### PR TITLE
check for reallocarray before using it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -210,7 +210,7 @@ AC_TYPE_UINT8_T
 
 # Checks for library functions.
 AC_FUNC_MMAP
-AC_CHECK_FUNCS([floor memmove memset munmap select setlocale sqrt strerror])
+AC_CHECK_FUNCS([floor memmove memset munmap reallocarray select setlocale sqrt strerror])
 
 AX_PTHREAD([LIBS="$PTHREAD_LIBS $LIBS"
             CFLAGS="$CFLAGS $PTHREAD_CFLAGS"], AC_MSG_ERROR(Can not find pthreads.  This is required.))

--- a/src/chart.cpp
+++ b/src/chart.cpp
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include "config.h"
 #include "compat.h"
 #include "egt/chart.h"
 #include "egt/detail/meta.h"


### PR DESCRIPTION
in kplot there is a runtime check for reallocarray which actually wont
work in cross compile mode, luckily it does check for HAVE_REALLOCARRAY
before usng the results of runtime check. So here add a configure time
check for presense of reallocarray

Fixes

TOPDIR/build/tmp/work/core2-32-yoe-linux/libegt/0.8-r0/recipe-sysroot/usr/include/stdlib.h:559:14: error: exception specification in declaration does not match previous declaration
extern void *reallocarray (void *__ptr, size_t __nmemb, size_t __size)
             ^
../external/kplot/compat.h:24:7: note: previous declaration is here
void *reallocarray(void *optr, size_t nmemb, size_t size);
      ^

Upstream-Status: Pending
Signed-off-by: Khem Raj <raj.khem@gmail.com>