### PR TITLE
Fix incorrect label text and bg enumerators

### DIFF
--- a/examples/floating/floating.cpp
+++ b/examples/floating/floating.cpp
@@ -203,7 +203,7 @@ int main(int argc, char** argv)
     movetimer.start();
 
     egt::Label label1("CPU: ----");
-    label1.color(egt::Palette::ColorId::text, egt::Palette::white);
+    label1.color(egt::Palette::ColorId::label_text, egt::Palette::white);
     win.add(bottom(left(label1)));
 
     egt::experimental::CPUMonitorUsage tools;

--- a/examples/space/space.cpp
+++ b/examples/space/space.cpp
@@ -158,8 +158,8 @@ int main(int argc, char** argv)
     spawntimer.start();
 
     egt::Label label1("CPU: ----");
-    label1.color(egt::Palette::ColorId::text, egt::Palette::white);
-    label1.color(egt::Palette::ColorId::bg, egt::Palette::transparent);
+    label1.color(egt::Palette::ColorId::label_text, egt::Palette::white);
+    label1.color(egt::Palette::ColorId::label_bg, egt::Palette::transparent);
     win.add(bottom(left(label1)));
 
     egt::experimental::CPUMonitorUsage tools;

--- a/examples/sprite/sprite.cpp
+++ b/examples/sprite/sprite.cpp
@@ -72,8 +72,8 @@ int main(int argc, char** argv)
     egt::Label label2("FPS: -",
                       egt::Rect(egt::Point(0, 40), egt::Size(100, 40)),
                       egt::AlignFlag::center);
-    label2.color(egt::Palette::ColorId::text, egt::Palette::black);
-    label2.color(egt::Palette::ColorId::bg, egt::Palette::transparent);
+    label2.color(egt::Palette::ColorId::label_text, egt::Palette::black);
+    label2.color(egt::Palette::ColorId::label_bg, egt::Palette::transparent);
 
 #define DEFAULT_MS_INTERVAL 100
 
@@ -132,8 +132,8 @@ int main(int argc, char** argv)
     egt::Label label1("CPU: -",
                       egt::Rect(egt::Point(0, 0), egt::Size(100, 40)),
                       egt::AlignFlag::center);
-    label1.color(egt::Palette::ColorId::text, egt::Palette::black);
-    label1.color(egt::Palette::ColorId::bg, egt::Palette::transparent);
+    label1.color(egt::Palette::ColorId::label_text, egt::Palette::black);
+    label1.color(egt::Palette::ColorId::label_bg, egt::Palette::transparent);
 
     popup.add(label1);
     popup.add(label2);

--- a/examples/squares/squares.cpp
+++ b/examples/squares/squares.cpp
@@ -28,8 +28,8 @@ int main(int argc, char** argv)
     egt::VerticalBoxSizer sizer;
 
     egt::Label label("FPS: ---");
-    label.color(egt::Palette::ColorId::text, egt::Palette::black);
-    label.color(egt::Palette::ColorId::bg, egt::Palette::transparent);
+    label.color(egt::Palette::ColorId::label_text, egt::Palette::black);
+    label.color(egt::Palette::ColorId::label_bg, egt::Palette::transparent);
     sizer.add(expand_horizontal(label));
 
     label.on_text_changed([&label]()
@@ -38,8 +38,8 @@ int main(int argc, char** argv)
     });
 
     egt::Label label_dims("");
-    label_dims.color(egt::Palette::ColorId::text, egt::Palette::black);
-    label_dims.color(egt::Palette::ColorId::bg, egt::Palette::transparent);
+    label_dims.color(egt::Palette::ColorId::label_text, egt::Palette::black);
+    label_dims.color(egt::Palette::ColorId::label_bg, egt::Palette::transparent);
     sizer.add(expand_horizontal(label_dims));
 
     label_dims.on_text_changed([&label_dims]()


### PR DESCRIPTION
Four examples incorrectly used the ::text and ::bg ColorId enumerators.
They should have used label_text and label_bg.

Signed-off-by: Matt Wood <matt.wood@microchip.com>