### PR TITLE
src/app.cpp: Check for right variable from config.h

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -26,7 +26,7 @@
 #include <clocale>
 #include <csignal>
 #include <iostream>
-#ifdef HAVE_LIBINTL_H
+#ifdef HAVE_LIBINTL
 #include <libintl.h>
 #endif
 #include <regex>


### PR DESCRIPTION
HAVE_LIBINTL_H is not populated by automake, only HAVE_LIBINTL is.

Signed-off-by: Khem Raj <raj.khem@gmail.com>