### PR TITLE
Allow non-zero exit values from app

### DIFF
--- a/examples/restart/appMonitor.sh
+++ b/examples/restart/appMonitor.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "appMonitor: starting egtApp"
+
+until ./egtApp; do
+    echo "appMonitor: egtApp exited abnormally with code $?.  Restarting.." >&2
+    sleep 1
+done
+
+echo "appMonitor: egtApp exited normally with code $?" >&2

--- a/examples/restart/egtApp.cpp
+++ b/examples/restart/egtApp.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2018 Microchip Technology Inc.  All rights reserved.
+ *
+ * Modified by Owen O'Hehir
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/// @[Example]
+#include <egt/ui>
+
+int main(int argc, char** argv)
+{
+    egt::Application app(argc, argv);
+
+    egt::TopWindow window;
+
+    egt::Button button_quit(window, "Quit");
+    egt::center(button_quit);
+    egt::top(button_quit);
+
+    egt::Button button_restart(window, "Restart");
+    egt::center(button_restart);
+
+    button_quit.on_click([&app](egt::Event&){
+    	app.instance().quit(0);
+    });
+
+    button_restart.on_click([&app](egt::Event&){
+    	app.instance().quit(1);
+    });
+
+    window.show();
+
+
+    return app.run();
+}
+/// @[Example]

--- a/include/egt/app.h
+++ b/include/egt/app.h
@@ -104,8 +104,9 @@ public:
 
     /**
      * Calls EventLoop::quit() by default.
+     * Allow non-zero exit value
      */
-    virtual void quit();
+    virtual void quit(const int exit_value = 0);
 
     /**
      * Get a reference to the application event loop instance.

--- a/include/egt/eventloop.h
+++ b/include/egt/eventloop.h
@@ -95,8 +95,9 @@ public:
      * Quit the event loop.
      *
      * This will cause the run() function to return.
+     * @note Allow optional non-zero exit value
      */
-    void quit();
+    void quit(const int);
 
     /**
      * Event callback function definition.
@@ -131,6 +132,9 @@ protected:
 
     /// Used internally to determine whether the event loop should exit.
     bool m_do_quit{false};
+
+    /// Return value when application quits
+    int m_exit_value;
 
     /// Application reference.
     const Application& m_app;

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -383,9 +383,9 @@ int Application::run()
     return m_event.run();
 }
 
-void Application::quit()
+void Application::quit(const int exit_value)
 {
-    m_event.quit();
+    m_event.quit(exit_value);
 }
 
 void Application::paint_to_file(const std::string& filename)

--- a/src/detail/screen/x11screen.cpp
+++ b/src/detail/screen/x11screen.cpp
@@ -240,7 +240,7 @@ void X11Screen::handle_read(const asio::error_code& error)
         case ClientMessage:
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
             if (static_cast<int>(e.xclient.data.l[0]) == static_cast<int>(m_priv->wmDeleteMessage))
-                m_app.event().quit();
+                m_app.event().quit(0);
             break;
         }
     }

--- a/src/eventloop.cpp
+++ b/src/eventloop.cpp
@@ -30,7 +30,9 @@ struct EventLoop::EventLoopImpl
 EventLoop::EventLoop(const Application& app) noexcept
     : m_impl(std::make_unique<EventLoopImpl>()),
       m_app(app)
-{}
+{
+    m_exit_value = -1;
+}
 
 asio::io_context& EventLoop::io()
 {
@@ -88,8 +90,9 @@ int EventLoop::wait()
     return ret;
 }
 
-void EventLoop::quit()
+void EventLoop::quit(const int exit_value)
 {
+    m_exit_value = exit_value;
     m_do_quit = true;
     m_impl->m_io.stop();
 }
@@ -172,7 +175,7 @@ int EventLoop::run()
 
     EGTLOG_TRACE("EventLoop::run() exiting");
 
-    return 0;
+    return m_exit_value;
 }
 
 void EventLoop::add_idle_callback(IdleCallback func)


### PR DESCRIPTION
Suggest to modify Application::instance().quit() to allow it to pass values to EventLoop::quit(). 

By doing so it allows the EGT application to exit with non-zero return value which can be used by a monitoring program (e.g. bash script) to detect a normal/ clean exit or a request for restart.

Demo application included to demonstrate functionality.

Application::instance().quit() function prototype includes default value (0) so shouldn't break existing applications